### PR TITLE
updated to poppler-0.62.0 on Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ src/pdf2htmlEX-config.h
 src/util/css_const.h
 test export-ignore
 Testing/*
+DartConfiguration.tcl
+test/test.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+compile_commands.json
 CMakeCache.txt
 CMakeFiles/*
 cmake_install.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 compile_commands.json
 CMakeCache.txt
 CMakeFiles/*

--- a/3rdparty/poppler/git/CairoFontEngine.cc
+++ b/3rdparty/poppler/git/CairoFontEngine.cc
@@ -34,6 +34,16 @@
 //
 //========================================================================
 
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
+//
+//========================================================================
+
+
 #include <poppler-config.h>
 
 #include <string.h>
@@ -180,7 +190,7 @@ _ft_new_face_uncached (FT_Library lib,
   FT_Face face;
   cairo_font_face_t *font_face;
 
-  if (font_data == nullptr) {
+  if (font_data == NULL) {
     if (FT_New_Face (lib, filename, 0, &face))
       return gFalse;
   } else {
@@ -286,7 +296,7 @@ _ft_new_face (FT_Library lib,
 
   tmpl.fd = -1;
 
-  if (font_data == nullptr) {
+  if (font_data == NULL) {
     /* if we fail to mmap the file, just pass it to FreeType instead */
     tmpl.fd = open (filename, O_RDONLY);
     if (tmpl.fd == -1)
@@ -297,7 +307,7 @@ _ft_new_face (FT_Library lib,
       return _ft_new_face_uncached (lib, filename, font_data, font_data_len, face_out, font_face_out);
     }
 
-    tmpl.bytes = (unsigned char *) mmap (nullptr, st.st_size,
+    tmpl.bytes = (unsigned char *) mmap (NULL, st.st_size,
 					 PROT_READ, MAP_PRIVATE,
 					 tmpl.fd, 0);
     if (tmpl.bytes == MAP_FAILED) {
@@ -351,7 +361,7 @@ _ft_new_face (FT_Library lib,
 
   l = (struct _ft_face_data *) gmallocn (1, sizeof (struct _ft_face_data));
   *l = tmpl;
-  l->prev = nullptr;
+  l->prev = NULL;
   l->next = _ft_open_faces;
   if (_ft_open_faces)
     _ft_open_faces->prev = l;
@@ -411,20 +421,20 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
 
   int *codeToGID;
   Guint codeToGIDLen;
-
-  codeToGID = nullptr;
+  
+  codeToGID = NULL;
   codeToGIDLen = 0;
-  font_data = nullptr;
+  font_data = NULL;
   font_data_len = 0;
-  fileName = nullptr;
-  fileNameC = nullptr;
+  fileName = NULL;
+  fileNameC = NULL;
 
   GBool substitute = gFalse;
-
+  
   ref = *gfxFont->getID();
   fontType = gfxFont->getType();
 
-  if (!(fontLoc = gfxFont->locateFont(xref, nullptr))) {
+  if (!(fontLoc = gfxFont->locateFont(xref, NULL))) {
     error(errSyntaxError, -1, "Couldn't find a font for '{0:s}'",
     	gfxFont->getName() ? gfxFont->getName()->getCString()
 	                       : "(unnamed)");
@@ -434,7 +444,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
   // embedded font
   if (fontLoc->locType == gfxFontLocEmbedded) {
     font_data = gfxFont->readEmbFontFile(xref, &font_data_len);
-    if (nullptr == font_data)
+    if (NULL == font_data)
       goto err2;
 
   // external font
@@ -444,7 +454,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
     substitute = gTrue;
   }
 
-  if (fileName != nullptr) {
+  if (fileName != NULL) {
     fileNameC = fileName->getCString();
   }
 
@@ -456,9 +466,9 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
       error(errSyntaxError, -1, "could not create type1 face");
       goto err2;
     }
-
+    
     enc = ((Gfx8BitFont *)gfxFont)->getEncoding();
-
+    
     codeToGID = (int *)gmallocn(256, sizeof(int));
     codeToGIDLen = 256;
     for (i = 0; i < 256; ++i) {
@@ -481,7 +491,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
     break;
   case fontCIDType2:
   case fontCIDType2OT:
-    codeToGID = nullptr;
+    codeToGID = NULL;
     n = 0;
     if (((GfxCIDFont *)gfxFont)->getCIDToGID()) {
       n = ((GfxCIDFont *)gfxFont)->getCIDToGIDLen();
@@ -491,7 +501,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
 		n * sizeof(int));
       }
     } else {
-      if (font_data != nullptr) {
+      if (font_data != NULL) {
         ff = FoFiTrueType::make(font_data, font_data_len);
       } else {
         ff = FoFiTrueType::load(fileNameC);
@@ -505,7 +515,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
     /* Fall through */
   case fontTrueType:
   case fontTrueTypeOT:
-    if (font_data != nullptr) {
+    if (font_data != NULL) {
       ff = FoFiTrueType::make(font_data, font_data_len);
     } else {
       ff = FoFiTrueType::load(fileNameC);
@@ -525,16 +535,16 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
       goto err2;
     }
     break;
-
+    
   case fontCIDType0:
   case fontCIDType0C:
 
-    codeToGID = nullptr;
+    codeToGID = NULL;
     codeToGIDLen = 0;
 
     if (!useCIDs)
     {
-      if (font_data != nullptr) {
+      if (font_data != NULL) {
         ff1c = FoFiType1C::make(font_data, font_data_len);
       } else {
         ff1c = FoFiType1C::load(fileNameC);
@@ -552,7 +562,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
     break;
 
   case fontCIDType0COT:
-    codeToGID = nullptr;
+    codeToGID = NULL;
     n = 0;
     if (((GfxCIDFont *)gfxFont)->getCIDToGID()) {
       n = ((GfxCIDFont *)gfxFont)->getCIDToGIDLen();
@@ -566,7 +576,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
 
     if (!codeToGID) {
       if (!useCIDs) {
-	if (font_data != nullptr) {
+	if (font_data != NULL) {
 	  ff = FoFiTrueType::make(font_data, font_data_len);
 	} else {
 	  ff = FoFiTrueType::load(fileNameC);
@@ -603,7 +613,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
   gfree (codeToGID);
   gfree (font_data);
   fprintf (stderr, "some font thing failed\n");
-  return nullptr;
+  return NULL;
 }
 
 //------------------------------------------------------------------------
@@ -703,7 +713,7 @@ _render_type3_glyph (cairo_scaled_font_t  *scaled_font,
   box.y1 = mat[1];
   box.x2 = mat[2];
   box.y2 = mat[3];
-  gfx = new Gfx(info->doc, output_dev, resDict, &box, nullptr);
+  gfx = new Gfx(info->doc, output_dev, resDict, &box, NULL);
   output_dev->startDoc(info->doc, info->fontEngine);
   output_dev->startPage (1, gfx->getState(), gfx->getXRef());
   output_dev->setInType3Char(gTrue);
@@ -808,9 +818,9 @@ CairoFontEngine::CairoFontEngine(FT_Library libA) {
 
   lib = libA;
   for (i = 0; i < cairoFontCacheSize; ++i) {
-    fontCache[i] = nullptr;
+    fontCache[i] = NULL;
   }
-
+  
   FT_Int major, minor, patch;
   // as of FT 2.1.8, CID fonts are indexed by CID instead of GID
   FT_Library_Version(lib, &major, &minor, &patch);
@@ -823,7 +833,7 @@ CairoFontEngine::CairoFontEngine(FT_Library libA) {
 
 CairoFontEngine::~CairoFontEngine() {
   int i;
-
+  
   for (i = 0; i < cairoFontCacheSize; ++i) {
     if (fontCache[i])
       delete fontCache[i];
@@ -839,7 +849,7 @@ CairoFontEngine::getFont(GfxFont *gfxFont, PDFDoc *doc, GBool printing, XRef *xr
   Ref ref;
   CairoFont *font;
   GfxFontType fontType;
-
+  
   fontEngineLocker();
   ref = *gfxFont->getID();
 
@@ -853,7 +863,7 @@ CairoFontEngine::getFont(GfxFont *gfxFont, PDFDoc *doc, GBool printing, XRef *xr
       return font;
     }
   }
-
+  
   fontType = gfxFont->getType();
   if (fontType == fontType3)
     font = CairoType3Font::create (gfxFont, doc, this, printing, xref);

--- a/3rdparty/poppler/git/CairoFontEngine.h
+++ b/3rdparty/poppler/git/CairoFontEngine.h
@@ -15,7 +15,7 @@
 // under GPL version 2 or later
 //
 // Copyright (C) 2005, 2006 Kristian Høgsberg <krh@redhat.com>
-// Copyright (C) 2005, 2018 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2005 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2006, 2007 Jeff Muizelaar <jeff@infidigm.net>
 // Copyright (C) 2006, 2010 Carlos Garcia Campos <carlosgc@gnome.org>
 // Copyright (C) 2008, 2017 Adrian Johnson <ajohnson@redneon.com>
@@ -23,6 +23,15 @@
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
+//
+//========================================================================
+
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
 //
 //========================================================================
 
@@ -51,8 +60,6 @@ public:
 	    GBool substitute,
 	    GBool printing);
   virtual ~CairoFont();
-  CairoFont(const CairoFont &) = delete;
-  CairoFont& operator=(const CairoFont &other) = delete;
 
   virtual GBool matches(Ref &other, GBool printing);
   cairo_font_face_t *getFontFace(void);
@@ -116,8 +123,6 @@ public:
   // Create a font engine.
   CairoFontEngine(FT_Library libA);
   ~CairoFontEngine();
-  CairoFontEngine(const CairoFontEngine &) = delete;
-  CairoFontEngine& operator=(const CairoFontEngine &other) = delete;
 
   CairoFont *getFont(GfxFont *gfxFont, PDFDoc *doc, GBool printing, XRef *xref);
 

--- a/3rdparty/poppler/git/CairoOutputDev.cc
+++ b/3rdparty/poppler/git/CairoOutputDev.cc
@@ -35,6 +35,15 @@
 //
 //========================================================================
 
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
+//
+//========================================================================
+
 #include <poppler-config.h>
 
 #ifdef USE_GCC_PRAGMAS
@@ -69,11 +78,6 @@
 
 // #define LOG_CAIRO
 
-// To limit memory usage and improve performance when printing, limit
-// cairo images to this size. 8192 is sufficient for an A2 sized
-// 300ppi image.
-#define MAX_PRINT_IMAGE_SIZE 8192
-
 #ifdef LOG_CAIRO
 #define LOG(x) (x)
 #else
@@ -96,7 +100,7 @@ static inline void printMatrix(cairo_matrix_t *matrix){
 //------------------------------------------------------------------------
 
 CairoImage::CairoImage (double x1, double y1, double x2, double y2) {
-  this->image = nullptr;
+  this->image = NULL;
   this->x1 = x1;
   this->y1 = y1;
   this->x2 = x2;
@@ -128,26 +132,26 @@ FT_Library CairoOutputDev::ft_lib;
 GBool CairoOutputDev::ft_lib_initialized = gFalse;
 
 CairoOutputDev::CairoOutputDev() {
-  doc = nullptr;
+  doc = NULL;
 
   if (!ft_lib_initialized) {
     FT_Init_FreeType(&ft_lib);
     ft_lib_initialized = gTrue;
   }
 
-  fontEngine = nullptr;
+  fontEngine = NULL;
   fontEngine_owner = gFalse;
-  glyphs = nullptr;
-  fill_pattern = nullptr;
+  glyphs = NULL;
+  fill_pattern = NULL;
   fill_color.r = fill_color.g = fill_color.b = 0;
-  stroke_pattern = nullptr;
+  stroke_pattern = NULL;
   stroke_color.r = stroke_color.g = stroke_color.b = 0;
   stroke_opacity = 1.0;
   fill_opacity = 1.0;
-  textClipPath = nullptr;
-  strokePathClip = nullptr;
-  cairo = nullptr;
-  currentFont = nullptr;
+  textClipPath = NULL;
+  strokePathClip = NULL;
+  cairo = NULL;
+  currentFont = NULL;
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 14, 0)
   prescaleImages = gFalse;
 #else
@@ -161,23 +165,23 @@ CairoOutputDev::CairoOutputDev() {
   text_matrix_valid = gTrue;
   antialias = CAIRO_ANTIALIAS_DEFAULT;
 
-  groupColorSpaceStack = nullptr;
-  maskStack = nullptr;
-  group = nullptr;
-  mask = nullptr;
-  shape = nullptr;
-  cairo_shape = nullptr;
+  groupColorSpaceStack = NULL;
+  maskStack = NULL;
+  group = NULL;
+  mask = NULL;
+  shape = NULL;
+  cairo_shape = NULL;
   knockoutCount = 0;
 
-  text = nullptr;
-  actualText = nullptr;
+  text = NULL;
+  actualText = NULL;
 
   // the SA parameter supposedly defaults to false, but Acrobat
   // apparently hardwires it to true
   stroke_adjust = gTrue;
   align_stroke_coords = gFalse;
   adjusted_stroke_width = gFalse;
-  xref = nullptr;
+  xref = NULL;
 }
 
 CairoOutputDev::~CairoOutputDev() {
@@ -195,15 +199,15 @@ CairoOutputDev::~CairoOutputDev() {
     cairo_pattern_destroy (mask);
   if (shape)
     cairo_pattern_destroy (shape);
-  if (text)
+  if (text) 
     text->decRefCnt();
   if (actualText)
-    delete actualText;
+    delete actualText;  
 }
 
 void CairoOutputDev::setCairo(cairo_t *cairo)
 {
-  if (this->cairo != nullptr) {
+  if (this->cairo != NULL) {
     cairo_status_t status = cairo_status (this->cairo);
     if (status) {
       error(errInternal, -1, "cairo context error: {0:s}\n", cairo_status_to_string(status));
@@ -211,21 +215,21 @@ void CairoOutputDev::setCairo(cairo_t *cairo)
     cairo_destroy (this->cairo);
     assert(!cairo_shape);
   }
-  if (cairo != nullptr) {
+  if (cairo != NULL) {
     this->cairo = cairo_reference (cairo);
 	/* save the initial matrix so that we can use it for type3 fonts. */
 	//XXX: is this sufficient? could we miss changes to the matrix somehow?
 	cairo_get_matrix(cairo, &orig_matrix);
 	setContextAntialias(cairo, antialias);
   } else {
-    this->cairo = nullptr;
-    this->cairo_shape = nullptr;
+    this->cairo = NULL;
+    this->cairo_shape = NULL;
   }
 }
 
 void CairoOutputDev::setTextPage(TextPage *text)
 {
-  if (this->text)
+  if (this->text) 
     this->text->decRefCnt();
   if (actualText)
     delete actualText;
@@ -234,8 +238,8 @@ void CairoOutputDev::setTextPage(TextPage *text)
     this->text->incRefCnt();
     actualText = new ActualText(text);
   } else {
-    this->text = nullptr;
-    actualText = nullptr;
+    this->text = NULL;
+    actualText = NULL;
   }
 }
 
@@ -286,7 +290,7 @@ void CairoOutputDev::startPage(int pageNum, GfxState *state, XRef *xrefA) {
 
   if (text)
     text->startPage(state);
-  if (xrefA != nullptr) {
+  if (xrefA != NULL) {
     xref = xrefA;
   }
 }
@@ -345,7 +349,7 @@ void CairoOutputDev::restoreState(GfxState *state) {
     if (strokePathClip->dashes)
       gfree (strokePathClip->dashes);
     gfree (strokePathClip);
-    strokePathClip = nullptr;
+    strokePathClip = NULL;
   }
 }
 
@@ -669,7 +673,7 @@ void CairoOutputDev::updateFont(GfxState *state) {
   //FIXME: use cairo font engine?
   if (text)
     text->updateFont(state);
-
+  
   currentFont = fontEngine->getFont (state->getFont(), doc, printing, xref);
 
   if (!currentFont)
@@ -680,7 +684,7 @@ void CairoOutputDev::updateFont(GfxState *state) {
 
   use_show_text_glyphs = state->getFont()->hasToUnicodeCMap() &&
     cairo_surface_has_show_text_glyphs (cairo_get_target (cairo));
-
+ 
   double fontSize = state->getFontSize();
   double *m = state->getTextMat();
   /* NOTE: adjusting by a constant is hack. The correct solution
@@ -955,11 +959,11 @@ GBool CairoOutputDev::tilingPatternFill(GfxState *state, Gfx *gfxA, Catalog *cat
   cairo_translate (cairo, -box.x1, -box.y1);
 
   strokePathTmp = strokePathClip;
-  strokePathClip = nullptr;
+  strokePathClip = NULL;
   adjusted_stroke_width_tmp = adjusted_stroke_width;
   maskTmp = mask;
-  mask = nullptr;
-  gfx = new Gfx(doc, this, resDict, &box, nullptr, nullptr, nullptr, gfxA->getXRef());
+  mask = NULL;
+  gfx = new Gfx(doc, this, resDict, &box, NULL, NULL, NULL, gfxA->getXRef());
   if (paintType == 2)
     inUncoloredPattern = gTrue;
   gfx->display(str);
@@ -1356,7 +1360,7 @@ void CairoOutputDev::clipToStrokePath(GfxState *state) {
     strokePathClip->dashes = (double*) gmallocn (sizeof(double), strokePathClip->dash_count);
     cairo_get_dash (cairo, strokePathClip->dashes, &strokePathClip->dash_offset);
   } else {
-    strokePathClip->dashes = nullptr;
+    strokePathClip->dashes = NULL;
   }
   strokePathClip->cap = cairo_get_line_cap (cairo);
   strokePathClip->join = cairo_get_line_join (cairo);
@@ -1493,11 +1497,11 @@ void CairoOutputDev::endString(GfxState *state)
       }
       cairo_path_destroy (textClipPath);
     }
-
+    
     // append the glyph path
     cairo_glyph_path (cairo, glyphs, glyphCount);
-
-    // move the path back into textClipPath
+   
+    // move the path back into textClipPath 
     // and clear the current path
     textClipPath = cairo_copy_path (cairo);
     cairo_new_path (cairo);
@@ -1508,12 +1512,12 @@ void CairoOutputDev::endString(GfxState *state)
 
 finish:
   gfree (glyphs);
-  glyphs = nullptr;
+  glyphs = NULL;
   if (use_show_text_glyphs) {
     gfree (clusters);
-    clusters = nullptr;
+    clusters = NULL;
     gfree (utf8);
-    utf8 = nullptr;
+    utf8 = NULL;
   }
 }
 
@@ -1584,7 +1588,7 @@ void CairoOutputDev::endTextObject(GfxState *state) {
       cairo_clip (cairo_shape);
     }
     cairo_path_destroy (textClipPath);
-    textClipPath = nullptr;
+    textClipPath = NULL;
   }
 }
 
@@ -1616,7 +1620,7 @@ static
 cairo_surface_t *cairo_surface_create_similar_clip (cairo_t *cairo, cairo_content_t content)
 {
   cairo_pattern_t *pattern;
-  cairo_surface_t *surface = nullptr;
+  cairo_surface_t *surface = NULL;
 
   cairo_push_group_with_content (cairo, content);
   pattern = cairo_pop_group (cairo);
@@ -1728,7 +1732,7 @@ void CairoOutputDev::paintTransparencyGroup(GfxState * /*state*/, double * /*bbo
       cairo_paint_with_alpha (cairo, fill_opacity);
     }
     cairo_pattern_destroy(mask);
-    mask = nullptr;
+    mask = NULL;
   }
 
   if (shape) {
@@ -1738,7 +1742,7 @@ void CairoOutputDev::paintTransparencyGroup(GfxState * /*state*/, double * /*bbo
       cairo_set_source_rgb (cairo_shape, 0, 0, 0);
     }
     cairo_pattern_destroy (shape);
-    shape = nullptr;
+    shape = NULL;
   }
 
   popTransparencyGroup();
@@ -1886,7 +1890,7 @@ void CairoOutputDev::popTransparencyGroup() {
       /* we don't need to track the shape anymore because
        * we are not above any knockout groups */
       cairo_destroy(cairo_shape);
-      cairo_shape = nullptr;
+      cairo_shape = NULL;
     }
   }
   groupColorSpaceStack = css->next;
@@ -1897,7 +1901,7 @@ void CairoOutputDev::popTransparencyGroup() {
 void CairoOutputDev::clearSoftMask(GfxState * /*state*/) {
   if (mask)
     cairo_pattern_destroy(mask);
-  mask = nullptr;
+  mask = NULL;
 }
 
 /* Taken from cairo/doc/tutorial/src/singular.c */
@@ -1970,7 +1974,7 @@ CairoOutputDev::getFilterForSurface(cairo_surface_t *image,
 				    GBool interpolate)
 {
   if (interpolate)
-    return CAIRO_FILTER_BEST;
+    return CAIRO_FILTER_GOOD;
 
   int orig_width = cairo_image_surface_get_width (image);
   int orig_height = cairo_image_surface_get_height (image);
@@ -1990,7 +1994,7 @@ CairoOutputDev::getFilterForSurface(cairo_surface_t *image,
   if (scaled_width / orig_width >= 4 || scaled_height / orig_height >= 4)
 	  return CAIRO_FILTER_NEAREST;
 
-  return CAIRO_FILTER_BEST;
+  return CAIRO_FILTER_GOOD;
 }
 
 void CairoOutputDev::drawImageMask(GfxState *state, Object *ref, Stream *str,
@@ -2033,7 +2037,7 @@ void CairoOutputDev::drawImageMask(GfxState *state, Object *ref, Stream *str,
 
   cairo_matrix_t matrix;
   cairo_get_matrix (cairo, &matrix);
-  //XXX: it is possible that we should only do sub pixel positioning if
+  //XXX: it is possible that we should only do sub pixel positioning if 
   // we are rendering fonts */
   if (!printing && prescaleImages
       /* not rotated */
@@ -2086,7 +2090,7 @@ void CairoOutputDev::setSoftMaskFromImageMask(GfxState *state, Object *ref, Stre
 
     cairo_matrix_t matrix;
     cairo_get_matrix (cairo, &matrix);
-    //XXX: it is possible that we should only do sub pixel positioning if
+    //XXX: it is possible that we should only do sub pixel positioning if 
     // we are rendering fonts */
     if (!printing && prescaleImages && matrix.xy == 0.0 && matrix.yx == 0.0) {
       drawImageMaskPrescaled(state, ref, str, width, height, invert, gFalse, inlineImg);
@@ -2458,7 +2462,7 @@ void CairoOutputDev::drawImageMaskPrescaled(GfxState *state, Object *ref, Stream
    * cairo doesn't yet do minifaction filtering causing scaled down
    * images with CAIRO_FILTER_NEAREST to look really bad */
   cairo_pattern_set_filter (pattern,
-			    interpolate ? CAIRO_FILTER_BEST : CAIRO_FILTER_FAST);
+			    interpolate ? CAIRO_FILTER_GOOD : CAIRO_FILTER_FAST);
 
   if (state->getFillColorSpace()->getMode() == csPattern) {
     cairo_matrix_init_translate (&matrix, 0, scaledHeight);
@@ -2588,7 +2592,7 @@ void CairoOutputDev::drawMaskedImage(GfxState *state, Object *ref,
    * so check its underlying color space as well */
   int is_identity_transform;
   is_identity_transform = colorMap->getColorSpace()->getMode() == csDeviceRGB ||
-		  (colorMap->getColorSpace()->getMode() == csICCBased &&
+		  (colorMap->getColorSpace()->getMode() == csICCBased && 
 		   ((GfxICCBasedColorSpace*)colorMap->getColorSpace())->getAlt()->getMode() == csDeviceRGB);
 #endif
 
@@ -2766,7 +2770,7 @@ void CairoOutputDev::drawSoftMaskedImage(GfxState *state, Object *ref, Stream *s
 
   cairo_surface_mark_dirty (image);
 
-  setMimeData(state, str, ref, colorMap, image, height);
+  setMimeData(state, str, ref, colorMap, image);
 
   pattern = cairo_pattern_create_for_surface (image);
   cairo_surface_destroy (image);
@@ -2920,7 +2924,7 @@ GBool CairoOutputDev::setMimeDataForJBIG2Globals(Stream  *str,
   if (!globalsStr->isStream())
     return gTrue;
 
-  if (setMimeIdFromRef(image, CAIRO_MIME_TYPE_JBIG2_GLOBAL_ID, nullptr,
+  if (setMimeIdFromRef(image, CAIRO_MIME_TYPE_JBIG2_GLOBAL_ID, NULL,
                        jb2Str->getGlobalsStreamRef()))
     return gFalse;
 
@@ -2940,38 +2944,8 @@ GBool CairoOutputDev::setMimeDataForJBIG2Globals(Stream  *str,
 }
 #endif
 
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 10)
-GBool CairoOutputDev::setMimeDataForCCITTParams(Stream  *str,
-						cairo_surface_t *image, int height)
-{
-  CCITTFaxStream *ccittStr = static_cast<CCITTFaxStream *>(str);
-
-  GooString params;
-  params.appendf("Columns={0:d}", ccittStr->getColumns());
-  params.appendf(" Rows={0:d}", height);
-  params.appendf(" K={0:d}", ccittStr->getEncoding());
-  params.appendf(" EndOfLine={0:d}", ccittStr->getEndOfLine() ? 1 : 0);
-  params.appendf(" EncodedByteAlign={0:d}", ccittStr->getEncodedByteAlign() ? 1 : 0);
-  params.appendf(" EndOfBlock={0:d}", ccittStr->getEndOfBlock() ? 1 : 0);
-  params.appendf(" BlackIs1={0:d}", ccittStr->getBlackIs1() ? 1 : 0);
-  params.appendf(" DamagedRowsBeforeError={0:d}", ccittStr->getDamagedRowsBeforeError());
-
-  char *p = strdup(params.getCString());
-  if (cairo_surface_set_mime_data (image, CAIRO_MIME_TYPE_CCITT_FAX_PARAMS,
-                                   (const unsigned char*)p,
-                                   params.getLength(),
-                                   gfree, (void*)p))
-  {
-    gfree (p);
-    return gFalse;
-  }
-
-  return gTrue;
-}
-#endif
-
 void CairoOutputDev::setMimeData(GfxState *state, Stream *str, Object *ref,
-				 GfxImageColorMap *colorMap, cairo_surface_t *image, int height)
+				 GfxImageColorMap *colorMap, cairo_surface_t *image)
 {
   char *strBuffer;
   int len;
@@ -2995,17 +2969,12 @@ void CairoOutputDev::setMimeData(GfxState *state, Stream *str, Object *ref,
       mime_type = CAIRO_MIME_TYPE_JBIG2;
       break;
 #endif
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 10)
-    case strCCITTFax:
-      mime_type = CAIRO_MIME_TYPE_CCITT_FAX;
-      break;
-#endif
     default:
       return;
   }
 
   obj = str->getDict()->lookup("ColorSpace");
-  colorSpace = GfxColorSpace::parse(nullptr, &obj, this, state);
+  colorSpace = GfxColorSpace::parse(NULL, &obj, this, state);
 
   // colorspace in stream dict may be different from colorspace in jpx
   // data
@@ -3039,11 +3008,6 @@ void CairoOutputDev::setMimeData(GfxState *state, Stream *str, Object *ref,
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 14, 0)
   if (strKind == strJBIG2 && !setMimeDataForJBIG2Globals(str, image))
-    return;
-#endif
-
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 10)
-  if (strKind == strCCITTFax && !setMimeDataForCCITTParams(str, image, height))
     return;
 #endif
 
@@ -3084,10 +3048,10 @@ public:
                                   GBool printing,
                                   GfxImageColorMap *colorMapA,
                                   int *maskColorsA) {
-    cairo_surface_t *image = nullptr;
+    cairo_surface_t *image = NULL;
     int i;
 
-    lookup = nullptr;
+    lookup = NULL;
     colorMap = colorMapA;
     maskColors = maskColorsA;
     width = widthA;
@@ -3130,22 +3094,7 @@ public:
     bool needsCustomDownscaling = true;
 #endif
 
-    if (printing) {
-      if (width > MAX_PRINT_IMAGE_SIZE || height > MAX_PRINT_IMAGE_SIZE) {
-	if (width > height) {
-	  scaledWidth = MAX_PRINT_IMAGE_SIZE;
-	  scaledHeight = MAX_PRINT_IMAGE_SIZE * (double)height/width;
-	} else {
-	  scaledHeight = MAX_PRINT_IMAGE_SIZE;
-	  scaledWidth = MAX_PRINT_IMAGE_SIZE * (double)width/height;
-	}
-	needsCustomDownscaling = true;
-      } else {
-	needsCustomDownscaling = false;
-      }
-    }
-
-    if (!needsCustomDownscaling || scaledWidth >= width || scaledHeight >= height) {
+    if (!needsCustomDownscaling || printing || scaledWidth >= width || scaledHeight >= height) {
       // No downscaling. Create cairo image containing the source image data.
       unsigned char *buffer;
       ptrdiff_t stride;
@@ -3204,7 +3153,7 @@ public:
       current_row++;
     }
 
-    if (unlikely(pix == nullptr)) {
+    if (unlikely(pix == NULL)) {
       memset(row_data, 0, width*4);
       if (!imageError) {
 	error(errInternal, -1, "Bad image stream");
@@ -3259,7 +3208,7 @@ void CairoOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   cairo_matrix_t matrix;
   int width, height;
   int scaledWidth, scaledHeight;
-  cairo_filter_t filter = CAIRO_FILTER_BEST;
+  cairo_filter_t filter = CAIRO_FILTER_GOOD;
   RescaleDrawImage rescale;
 
   LOG (printf ("drawImage %dx%d\n", widthA, heightA));
@@ -3275,17 +3224,8 @@ void CairoOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   if (width == widthA && height == heightA)
     filter = getFilterForSurface (image, interpolate);
 
-  if (!inlineImg) { /* don't read stream twice if it is an inline image */
-    // cairo 1.15.10 allows mime image data to have different size to cairo image
-    // mime image size will be scaled to same size as cairo image
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 10)
-    bool requireSameSize = false;
-#else
-    bool requireSameSize = true;
-#endif
-    if (!requireSameSize || (width == widthA && height == heightA))
-      setMimeData(state, str, ref, colorMap, image, heightA);
-  }
+  if (!inlineImg) /* don't read stream twice if it is an inline image */
+    setMimeData(state, str, ref, colorMap, image);
 
   pattern = cairo_pattern_create_for_surface (image);
   cairo_surface_destroy (image);
@@ -3310,7 +3250,7 @@ void CairoOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   } else if (mask) {
     maskPattern = cairo_pattern_reference (mask);
   } else {
-    maskPattern = nullptr;
+    maskPattern = NULL;
   }
 
   cairo_save (cairo);
@@ -3355,11 +3295,11 @@ void CairoOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
 
 CairoImageOutputDev::CairoImageOutputDev()
 {
-  images = nullptr;
+  images = NULL;
   numImages = 0;
   size = 0;
-  imgDrawCbk = nullptr;
-  imgDrawCbkData = nullptr;
+  imgDrawCbk = NULL;
+  imgDrawCbkData = NULL;
 }
 
 CairoImageOutputDev::~CairoImageOutputDev()
@@ -3372,7 +3312,7 @@ CairoImageOutputDev::~CairoImageOutputDev()
 }
 
 void CairoImageOutputDev::saveImage(CairoImage *image)
-{
+{ 
   if (numImages >= size) {
 	  size += 16;
 	  images = (CairoImage **) greallocn (images, size, sizeof (CairoImage *));
@@ -3432,7 +3372,7 @@ void CairoImageOutputDev::drawImageMask(GfxState *state, Object *ref, Stream *st
     CairoOutputDev::drawImageMask(state, ref, str, width, height, invert, interpolate, inlineImg);
     image->setImage (surface);
 
-    setCairo (nullptr);
+    setCairo (NULL);
     cairo_surface_destroy (surface);
     cairo_destroy (cr);
   }
@@ -3465,7 +3405,7 @@ void CairoImageOutputDev::setSoftMaskFromImageMask(GfxState *state, Object *ref,
     }
     image->setImage (surface);
 
-    setCairo (nullptr);
+    setCairo (NULL);
     cairo_surface_destroy (surface);
     cairo_destroy (cr);
   }
@@ -3491,11 +3431,11 @@ void CairoImageOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
     setCairo (cr);
     cairo_translate (cr, 0, height);
     cairo_scale (cr, width, -height);
-
+    
     CairoOutputDev::drawImage(state, ref, str, width, height, colorMap, interpolate, maskColors, inlineImg);
     image->setImage (surface);
-
-    setCairo (nullptr);
+    
+    setCairo (NULL);
     cairo_surface_destroy (surface);
     cairo_destroy (cr);
   }
@@ -3526,12 +3466,12 @@ void CairoImageOutputDev::drawSoftMaskedImage(GfxState *state, Object *ref, Stre
     setCairo (cr);
     cairo_translate (cr, 0, height);
     cairo_scale (cr, width, -height);
-
+    
     CairoOutputDev::drawSoftMaskedImage(state, ref, str, width, height, colorMap, interpolate,
 					maskStr, maskWidth, maskHeight, maskColorMap, maskInterpolate);
     image->setImage (surface);
-
-    setCairo (nullptr);
+    
+    setCairo (NULL);
     cairo_surface_destroy (surface);
     cairo_destroy (cr);
   }
@@ -3561,12 +3501,12 @@ void CairoImageOutputDev::drawMaskedImage(GfxState *state, Object *ref, Stream *
     setCairo (cr);
     cairo_translate (cr, 0, height);
     cairo_scale (cr, width, -height);
-
+    
     CairoOutputDev::drawMaskedImage(state, ref, str, width, height, colorMap, interpolate,
 				    maskStr, maskWidth, maskHeight, maskInvert, maskInterpolate);
     image->setImage (surface);
-
-    setCairo (nullptr);
+    
+    setCairo (NULL);
     cairo_surface_destroy (surface);
     cairo_destroy (cr);
   }

--- a/3rdparty/poppler/git/CairoOutputDev.h
+++ b/3rdparty/poppler/git/CairoOutputDev.h
@@ -23,10 +23,18 @@
 // Copyright (C) 2010-2013 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2015 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 // Copyright (C) 2016 Jason Crain <jason@aquaticape.us>
-// Copyright (C) 2018 Albert Astals Cid <aacid@kde.org>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
+//
+//========================================================================
+
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
 //
 //========================================================================
 
@@ -63,9 +71,6 @@ public:
 
   // Destructor.
   ~CairoImage ();
-
-  CairoImage(const CairoImage &) = delete;
-  CairoImage& operator=(const CairoImage &) = delete;
 
   // Set the image cairo surface
   void setImage (cairo_surface_t *image);
@@ -287,14 +292,11 @@ protected:
 				     GBool interpolate);
   GBool getStreamData (Stream *str, char **buffer, int *length);
   void setMimeData(GfxState *state, Stream *str, Object *ref,
-		   GfxImageColorMap *colorMap, cairo_surface_t *image, int height);
+		   GfxImageColorMap *colorMap, cairo_surface_t *image);
   void fillToStrokePathClip(GfxState *state);
   void alignStrokeCoords(GfxSubpath *subpath, int i, double *x, double *y);
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 14, 0)
   GBool setMimeDataForJBIG2Globals (Stream *str, cairo_surface_t *image);
-#endif
-#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 10)
-  GBool setMimeDataForCCITTParams(Stream  *str, cairo_surface_t *image, int height);
 #endif
   static void setContextAntialias(cairo_t *cr, cairo_antialias_t antialias);
 

--- a/3rdparty/poppler/git/CairoRescaleBox.cc
+++ b/3rdparty/poppler/git/CairoRescaleBox.cc
@@ -38,6 +38,14 @@
 //
 //========================================================================
 
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
+//
+//========================================================================
 
 /* This implements a box filter that supports non-integer box sizes */
 
@@ -271,9 +279,9 @@ GBool CairoRescaleBox::downScaleImage(unsigned orig_width, unsigned orig_height,
   int dest_y;
   int src_y = 0;
   uint32_t *scanline;
-  int *x_coverage = nullptr;
-  int *y_coverage = nullptr;
-  uint32_t *temp_buf = nullptr;
+  int *x_coverage = NULL;
+  int *y_coverage = NULL;
+  uint32_t *temp_buf = NULL;
   GBool retval = gFalse;
   unsigned int *dest;
   int dst_stride;

--- a/3rdparty/poppler/git/CairoRescaleBox.h
+++ b/3rdparty/poppler/git/CairoRescaleBox.h
@@ -30,10 +30,18 @@
 // under GPL version 2 or later
 //
 // Copyright (C) 2012 Adrian Johnson <ajohnson@redneon.com>
-// Copyright (C) 2018 Albert Astals Cid <aacid@kde.org>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
+//
+//========================================================================
+
+//========================================================================
+//
+// Copied from Ubuntu 18.04 apt-get source poppler (poppler-0.62.0)
+// Copied on 2019/March/26
+// Copied by Stephen Gaito in order to update pdf2htmlEX poppler dependencies
+// Corrected <config.h> includes to <poppler-config.h>
 //
 //========================================================================
 
@@ -48,9 +56,6 @@ public:
 
   CairoRescaleBox() {};
   virtual ~CairoRescaleBox() {};
-
-  CairoRescaleBox(const CairoRescaleBox &) = delete;
-  CairoRescaleBox& operator=(const CairoRescaleBox &) = delete;
 
   virtual GBool downScaleImage(unsigned orig_width, unsigned orig_height,
                                signed scaled_width, signed scaled_height,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # leave this above project(pdf2htmlEX)
 # set default build type to Release
-set(CMAKE_EXPORT_COMPILE_COMMANDS, ON)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Build configuration (Debug, Release, RelWithDebInfo, MinSizeRel)")
 
 project(pdf2htmlEX)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
 
 option(ENABLE_SVG "Enable SVG support, for generating SVG background images and converting Type 3 fonts" ON)
@@ -71,12 +71,12 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
 # generic flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Woverloaded-virtual")
 
 # clang compiler need c++11 flag
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif()
+#if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+#endif()
 
 # CYGWIN or GCC 4.5.x bug
 if(CYGWIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # leave this above project(pdf2htmlEX)
 # set default build type to Release
+set(CMAKE_EXPORT_COMPILE_COMMANDS, ON)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Build configuration (Debug, Release, RelWithDebInfo, MinSizeRel)")
 
 project(pdf2htmlEX)

--- a/dobuild
+++ b/dobuild
@@ -1,4 +1,4 @@
 mkdir build
 cd build
 cmake ..
-make install
+make

--- a/dobuildClang
+++ b/dobuildClang
@@ -1,0 +1,4 @@
+mkdir build
+cd build
+CC=clang CXX=clang++ cmake ..
+make

--- a/doinstall
+++ b/doinstall
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "This installation assumes you have 'sudo' privileges"
+echo "Type ctrl-c now if DO NOT want to continue"
+read -p "Type anything else to continue: "
+
+cd build
+sudo make install

--- a/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -239,7 +239,7 @@ void CairoBackgroundRenderer::setMimeData(GfxState *state, Stream *str, Object *
 {
     if (param.svg_embed_bitmap)
     {
-        CairoOutputDev::setMimeData(state, str, ref, colorMap, image, cairo_image_surface_get_height (image));
+        CairoOutputDev::setMimeData(state, str, ref, colorMap, image);
         return;
     }
 


### PR DESCRIPTION
I have just made the smallest changes I could (reasonably) make to update the pdf2htmlEX poppler dependencies to poppler-0.62.0 (on Ubuntu 18.04 LTS).

The 3rdparty/poppler/git/Cairo* files have been copied directly from the corresponding files in the poppler-0.62.0 source code. I have added a comment detailing where and when these files were copied. I have also corrected the original poppler code's use of <config.h> (local build time configuration) to the (install time header) <poppler-config.h>

The only change in the pdf2htmlEX code itself was to update the only use of CairoOutputDev::setMimeData to remove the (now) redundant image height parameter. This change is located in the file  src/BackgroundRenderer/CairoBackgroundRenderer.cc

I have updated the .gitignore file to ensure CMake intermediate files are not version controlled.

I have downloaded the Bible de Genève, Cheat Sheet, Scientific Paper, Full Circle Magazine, and Git Manual pdfs as listed in the Readme.md and run this (locally) installed version of pdf2htmlEX on each pdf and then manually viewed the results. All of these pdfs look correct when (roughly) compared to the corresponding html referenced in the Readme.md

I hope you find this pull request useful... I am certainly finding the pdf2htmlEX tool very useful.

Regards, 
Stephen Gaito