### PR TITLE
update pdf2htmlEX for poppler-0.75.0

### DIFF
--- a/src/HTMLRenderer/font.cc
+++ b/src/HTMLRenderer/font.cc
@@ -66,7 +66,7 @@ string HTMLRenderer::dump_embedded_font (GfxFont * font, FontInfo & info)
 
         auto * id = font->getID();
 
-        Object ref_obj(id->num, id->gen);
+        Object ref_obj(*id);
         //ref_obj.initRef(id->num, id->gen);
         font_obj = ref_obj.fetch(xref);
         //ref_obj.free();


### PR DESCRIPTION
update pdf2htmlEX for poppler-0.75.0

Poppler changed font id reference object creation which was used in pdf2htmlEX/src/HTMLRender/font.cc

This has been corrected and pdf2htmlEX now works.