### PR TITLE
[Fedora] Detect OS build info from /etc/os-release and /usr/lib/os-release

### DIFF
--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -52,6 +52,14 @@ elif test -r /etc/alpine-release ; then
   cat /etc/alpine-release
   export BUILD_OS=alpine
   export BUILD_DIST=$(cat /etc/alpine-release)
+elif test -r /etc/os-release ; then
+  cat /etc/os-release
+  export BUILD_OS=$(grep '^ID=' /etc/os-release | cut -d'=' -f2)
+  export BUILD_DIST=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2)
+elif test -r /usr/lib/os-release ; then
+  cat /usr/lib/os-release
+  export BUILD_OS=$(grep '^ID=' /usr/lib/os-release | cut -d'=' -f2)
+  export BUILD_DIST=$(grep '^VERSION_ID=' /usr/lib/os-release | cut -d'=' -f2)
 else
   echo "FAILURE: could not determine release"
   exit -1


### PR DESCRIPTION
Fedora distribution provides neither /etc/lsb-release nor /etc/alpine-release.

This pull request adds functionality to pull BUILD_OS and BUILD_DIST variables from /etc/os-release and /usr/lib/os-release, both of which are available on Fedora.

Source of truth used for parsing:
https://www.freedesktop.org/software/systemd/man/os-release.html

ID=
A lower-case string (no spaces or other characters outside of 09, az, ".", "_" and "-") identifying the operating system, excluding any version information and suitable for processing by scripts or usage in generated filenames. If not set, defaults to "ID=linux". Example: "ID=fedora" or "ID=debian".

VERSION_ID=
A lower-case string (mostly numeric, no spaces or other characters outside of 09, az, ".", "_" and "-") identifying the operating system version, excluding any OS name information or release code name, and suitable for processing by scripts or usage in generated filenames. This field is optional. Example: "VERSION_ID=17" or "VERSION_ID=11.04".