### PR TITLE
Fix in-document links

### DIFF
--- a/buildScripts/buildInstallLocallyApt
+++ b/buildScripts/buildInstallLocallyApt
@@ -11,7 +11,7 @@ export MAKE_PARALLEL="-j $(nproc)"
 # choose one of the following...
 #
 # export PDF2HTMLEX_BRANCH="<<YourTagHereWithNoSpaces>>"
-export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD | tr _ -)"
 
 # The following environment variable determines where the poppler,
 # poppler-data, fontforge and pdf2htmlEX packages are installed.

--- a/buildScripts/buildInstallLocallyDnf
+++ b/buildScripts/buildInstallLocallyDnf
@@ -11,7 +11,7 @@ export MAKE_PARALLEL="-j $(nproc)"
 # choose one of the following...
 #
 # export PDF2HTMLEX_BRANCH="<<YourTagHereWithNoSpaces>>"
-export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD | tr _ -)"
 
 # The following environment variable determines where the poppler,
 # poppler-data, fontforge and pdf2htmlEX packages are installed.

--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -45,7 +45,7 @@ export LINUX_DEPLOY_URL=https://artifacts.assassinate-you.net/artifactory/list/l
 ###################################################################
 
 if [ -z "$PDF2HTMLEX_BRANCH" ]; then
-  export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  export PDF2HTMLEX_BRANCH="$(git rev-parse --abbrev-ref HEAD | tr _ -)"
   if [ -z "$PDF2HTMLEX_BRANCH" ]; then
     echo ""
     read -p "Enter the pdf2htmlEX branch or version: " PDF2HTMLEX_BRANCH

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -329,7 +329,7 @@ Viewer.prototype = {
     }, false);
 
     // handle links
-    [this.container, this.outline].forEach(function(ele) {
+    [this.outline, ...Array.from(this.container.querySelectorAll('a.l'))].forEach(function(ele) {
       ele.addEventListener('click', self.link_handler.bind(self), false);
     });
 
@@ -804,6 +804,10 @@ Viewer.prototype = {
   link_handler : function (e) {
     var target = /** @type{Node} */(e.target);
     var detail_str = /** @type{string} */ (target.getAttribute('data-dest-detail'));
+    if (!detail_str) {
+      target = /** @type{Node} */(e.currentTarget);
+      detail_str = /** @type{string} */ (target.getAttribute('data-dest-detail'));
+    }
     if (!detail_str) return;
 
     if (this.config['view_history_handler']) {

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -329,7 +329,7 @@ Viewer.prototype = {
     }, false);
 
     // handle links
-    [this.outline, ...Array.from(this.container.querySelectorAll('a.l'))].forEach(function(ele) {
+    [this.outline].concat(Array.from(this.container.querySelectorAll('a.l'))).forEach(function(ele) {
       ele.addEventListener('click', self.link_handler.bind(self), false);
     });
 


### PR DESCRIPTION
Currently, in-document links do not link to their proper headings (they link to the top of the page), as opposed to the ones in the sidebar. This minor change corrects this issue.