### PR TITLE
Fix in-document links (supersedes #95)

### DIFF
--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -329,7 +329,7 @@ Viewer.prototype = {
     }, false);
 
     // handle links
-    [this.container, this.outline].forEach(function(ele) {
+    [this.outline].concat(Array.from(this.container.querySelectorAll('a.l'))).forEach(function(ele) {
       ele.addEventListener('click', self.link_handler.bind(self), false);
     });
 
@@ -804,6 +804,10 @@ Viewer.prototype = {
   link_handler : function (e) {
     var target = /** @type{Node} */(e.target);
     var detail_str = /** @type{string} */ (target.getAttribute('data-dest-detail'));
+    if (!detail_str) {
+      target = /** @type{Node} */(e.currentTarget);
+      detail_str = /** @type{string} */ (target.getAttribute('data-dest-detail'));
+    }
     if (!detail_str) return;
 
     if (this.config['view_history_handler']) {


### PR DESCRIPTION
Currently, in-document links do not link to their proper headings (they link to the top of the page), as opposed to the ones in the sidebar. This minor change corrects this issue.

Supersedes #95