### PR TITLE
Update poppler to 21.02.0 and fontforge to 20230101

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build the project
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Build project with APT
+        run: './buildScripts/buildInstallLocallyApt'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: my-artifact
+          path: pdf2htmlEX/build

--- a/buildScripts/getPoppler
+++ b/buildScripts/getPoppler
@@ -17,7 +17,7 @@ echo "Getting poppler version: $POPPLER_VERSION"
 
 rm -rf $POPPLER_VERSION.tar.xz
 rm -rf poppler
-rm -rf poppler-data-0.4.9.tar.gz
+rm -rf poppler-data-0.4.12.tar.gz
 rm -rf poppler-data
 
 set -ev
@@ -30,8 +30,8 @@ echo "Getting poppler-data version: 0.4.9"
 
 mv $POPPLER_VERSION poppler
 
-wget https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz
+wget https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz
 
-tar xvf poppler-data-0.4.9.tar.gz
+tar xvf poppler-data-0.4.12.tar.gz
 
-mv poppler-data-0.4.9 poppler-data
+mv poppler-data-0.4.12 poppler-data

--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -4,11 +4,12 @@
 # versions
 
 # see: https://poppler.freedesktop.org/releases.html
-# current working: 0.89.0
+# current working: 21.02.0
 
 export PDF2HTMLEX_VERSION=0.18.8.rc2
 
-export POPPLER_VERSION=poppler-0.89.0
+export POPPLER_VERSION=poppler-21.02.0
+#export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.88.0
 #export POPPLER_VERSION=poppler-0.87.0
 #export POPPLER_VERSION=poppler-0.86.1
@@ -20,9 +21,10 @@ export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.81.0
 
 # see: https://github.com/fontforge/fontforge/releases
-# current working: 20190801
+# current working: 20220308
 
-export FONTFORGE_VERSION=20220308
+export FONTFORGE_VERSION=20230101
+#export FONTFORGE_VERSION=20220308
 #export FONTFORGE_VERSION=20190801
 #export FONTFORGE_VERSION=20190413
 #export FONTFORGE_VERSION=20190413
@@ -50,7 +52,7 @@ if [ -z "$PDF2HTMLEX_BRANCH" ]; then
     echo ""
     read -p "Enter the pdf2htmlEX branch or version: " PDF2HTMLEX_BRANCH
     echo ""
-    if [ -z "$PDF2HTMLEX_BRANCH" ]; then 
+    if [ -z "$PDF2HTMLEX_BRANCH" ]; then
       echo "PDF2HTMLEX_BRANCH not set... so we can not build anything."
       exit 1
     fi

--- a/pdf2htmlEX/src/util/ffw.c
+++ b/pdf2htmlEX/src/util/ffw.c
@@ -19,7 +19,7 @@
 #include "SignalHandler.h"
 
 #include "ffw.h"                      // needed for:
-#include "gfile.h"                    //   FindProgDir
+#include "gfile.h"                    //   FindProgDir => FindProgRoot in 20230101
 #include "fontforge/autowidth.h"      //   FVRemoveKerns
 #include "fontforge/bitmapchar.h"     //   SFReplaceEncodingBDFProps
 #include "fontforge/cvimages.h"       //   FVImportImages
@@ -71,7 +71,7 @@ void ffw_init(const char* progPath, int debug)
 {
     ffwSetAction("initialize");
     char *localProgPath = strdup(progPath);
-    FindProgDir(localProgPath);
+    FindProgRoot(localProgPath);
     InitSimpleStuff();
     if ( default_encoding==NULL )
         default_encoding=FindOrMakeEncoding("ISO8859-1");
@@ -345,7 +345,7 @@ void ffw_reencode_raw2(const char ** mapping, int mapping_len, int force)
 
 void ffw_cidflatten(void)
 {
-    if(!cur_fv->sf->cidmaster) 
+    if(!cur_fv->sf->cidmaster)
     {
         fprintf(stderr, "Cannot flatten a non-CID font\n");
         return;


### PR DESCRIPTION
Hi all, this is an update for `poppler-21.02.0` , `poppler-data` to `0.4.12` and `fontforge-20230101` .
Higher versions of `poppler` are not compatible with the current `pdf2htmlEX` code and this update does not resolve the problem described in ([isue 80](https://github.com/pdf2htmlEX/pdf2htmlEX/issues/81)) and the more detailed analysis at https://github.com/pdf2htmlEX/pdf2htmlEX/issues/81#issuecomment-683417554

Saludos