### PR TITLE
Update Poppler to 23.12.0 and Fontforge to 20230101 (based on #145)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build the project
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Build project with APT
+        run: './buildScripts/buildInstallLocallyApt'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: my-artifact
+          path: pdf2htmlEX/build

--- a/buildScripts/buildPoppler
+++ b/buildScripts/buildPoppler
@@ -19,7 +19,10 @@ cmake                                       \
   -DENABLE_UNSTABLE_API_ABI_HEADERS=OFF     \
   -DBUILD_GTK_TESTS=OFF                     \
   -DBUILD_QT5_TESTS=OFF                     \
+  -DBUILD_QT6_TESTS=OFF                     \
   -DBUILD_CPP_TESTS=OFF                     \
+  -DBUILD_MANUAL_TESTS=OFF                  \
+  -DENABLE_BOOST=OFF                        \
   -DENABLE_SPLASH=ON                        \
   -DENABLE_UTILS=OFF                        \
   -DENABLE_CPP=OFF                          \
@@ -27,10 +30,17 @@ cmake                                       \
   -DENABLE_GOBJECT_INTROSPECTION=OFF        \
   -DENABLE_GTK_DOC=OFF                      \
   -DENABLE_QT5=OFF                          \
+  -DENABLE_QT6=OFF                          \
   -DENABLE_LIBOPENJPEG="none"               \
-  -DENABLE_CMS="none"                       \
   -DENABLE_DCTDECODER="libjpeg"             \
+  -DENABLE_CMS="none"                       \
+  -DENABLE_LCMS=OFF                         \
   -DENABLE_LIBCURL=OFF                      \
+  -DENABLE_LIBTIFF=OFF                      \
+  -DWITH_TIFF=OFF                           \
+  -DWITH_NSS3=OFF                           \
+  -DENABLE_NSS3=OFF                         \
+  -DENABLE_GPGME=OFF                        \
   -DENABLE_ZLIB=ON                          \
   -DENABLE_ZLIB_UNCOMPRESS=OFF              \
   -DUSE_FLOAT=OFF                           \
@@ -39,8 +49,6 @@ cmake                                       \
   -DEXTRA_WARN=OFF                          \
   -DWITH_JPEG=ON                            \
   -DWITH_PNG=ON                             \
-  -DWITH_TIFF=OFF                           \
-  -DWITH_NSS3=OFF                           \
   -DWITH_Cairo=ON                           \
   ..
 

--- a/buildScripts/getPoppler
+++ b/buildScripts/getPoppler
@@ -17,7 +17,7 @@ echo "Getting poppler version: $POPPLER_VERSION"
 
 rm -rf $POPPLER_VERSION.tar.xz
 rm -rf poppler
-rm -rf poppler-data-0.4.9.tar.gz
+rm -rf poppler-data-0.4.12.tar.gz
 rm -rf poppler-data
 
 set -ev
@@ -30,8 +30,8 @@ echo "Getting poppler-data version: 0.4.9"
 
 mv $POPPLER_VERSION poppler
 
-wget https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz
+wget https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz
 
-tar xvf poppler-data-0.4.9.tar.gz
+tar xvf poppler-data-0.4.12.tar.gz
 
-mv poppler-data-0.4.9 poppler-data
+mv poppler-data-0.4.12 poppler-data

--- a/buildScripts/getPoppler
+++ b/buildScripts/getPoppler
@@ -26,7 +26,7 @@ wget https://poppler.freedesktop.org/$POPPLER_VERSION.tar.xz
 
 tar xvf $POPPLER_VERSION.tar.xz
 
-echo "Getting poppler-data version: 0.4.9"
+echo "Getting poppler-data version: 0.4.12"
 
 mv $POPPLER_VERSION poppler
 

--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -4,11 +4,12 @@
 # versions
 
 # see: https://poppler.freedesktop.org/releases.html
-# current working: 23.12.0
+# current working: 24.01.0
 
 export PDF2HTMLEX_VERSION=0.18.8.rc2
 
-export POPPLER_VERSION=poppler-23.12.0
+export POPPLER_VERSION=poppler-24.01.0
+#export POPPLER_VERSION=poppler-23.12.0
 #export POPPLER_VERSION=poppler-21.02.0
 #export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.88.0

--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -4,11 +4,12 @@
 # versions
 
 # see: https://poppler.freedesktop.org/releases.html
-# current working: 0.89.0
+# current working: 21.02.0
 
 export PDF2HTMLEX_VERSION=0.18.8.rc2
 
-export POPPLER_VERSION=poppler-0.89.0
+export POPPLER_VERSION=poppler-21.02.0
+#export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.88.0
 #export POPPLER_VERSION=poppler-0.87.0
 #export POPPLER_VERSION=poppler-0.86.1
@@ -20,9 +21,10 @@ export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.81.0
 
 # see: https://github.com/fontforge/fontforge/releases
-# current working: 20190801
+# current working: 20220308
 
-export FONTFORGE_VERSION=20220308
+export FONTFORGE_VERSION=20230101
+#export FONTFORGE_VERSION=20220308
 #export FONTFORGE_VERSION=20190801
 #export FONTFORGE_VERSION=20190413
 #export FONTFORGE_VERSION=20190413
@@ -50,7 +52,7 @@ if [ -z "$PDF2HTMLEX_BRANCH" ]; then
     echo ""
     read -p "Enter the pdf2htmlEX branch or version: " PDF2HTMLEX_BRANCH
     echo ""
-    if [ -z "$PDF2HTMLEX_BRANCH" ]; then 
+    if [ -z "$PDF2HTMLEX_BRANCH" ]; then
       echo "PDF2HTMLEX_BRANCH not set... so we can not build anything."
       exit 1
     fi

--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -4,11 +4,12 @@
 # versions
 
 # see: https://poppler.freedesktop.org/releases.html
-# current working: 21.02.0
+# current working: 23.12.0
 
 export PDF2HTMLEX_VERSION=0.18.8.rc2
 
-export POPPLER_VERSION=poppler-21.02.0
+export POPPLER_VERSION=poppler-23.12.0
+#export POPPLER_VERSION=poppler-21.02.0
 #export POPPLER_VERSION=poppler-0.89.0
 #export POPPLER_VERSION=poppler-0.88.0
 #export POPPLER_VERSION=poppler-0.87.0
@@ -21,7 +22,7 @@ export POPPLER_VERSION=poppler-21.02.0
 #export POPPLER_VERSION=poppler-0.81.0
 
 # see: https://github.com/fontforge/fontforge/releases
-# current working: 20220308
+# current working: 20230101
 
 export FONTFORGE_VERSION=20230101
 #export FONTFORGE_VERSION=20220308

--- a/pdf2htmlEX/CMakeLists.txt
+++ b/pdf2htmlEX/CMakeLists.txt
@@ -104,7 +104,6 @@ set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS}
   -lglib-2.0
   -lgio-2.0
   -lgobject-2.0
-  -pthread
   -lz
   -lm
 )
@@ -122,36 +121,16 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Woverloaded-virtual")
 
-# clang compiler need c++11 flag
-#if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-#endif()
-
-# CYGWIN or GCC 4.5.x bug
-if(CYGWIN)
-# was: set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
-# the following change is untested:
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
-else()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread")
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} Threads::Threads)
+# Poppler-23.12.0 requires CXX17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CYGWIN)
+    set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
-
-# check the C++11 features we need
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-#include <vector>
-int main()
-{
-  char * ptr = nullptr;
-  std::vector<int> v;
-  auto f = [&](){ for(auto & i : v) ++i; };
-  f();
-}
-" CXX0X_SUPPORT)
-if(NOT CXX0X_SUPPORT)
-    message(FATAL_ERROR "Error: your compiler does not support C++0x/C++11, please update it.")
-endif()
-
 
 configure_file (${CMAKE_SOURCE_DIR}/src/pdf2htmlEX-config.h.in ${CMAKE_SOURCE_DIR}/src/pdf2htmlEX-config.h)
 configure_file (${CMAKE_SOURCE_DIR}/pdf2htmlEX.1.in ${CMAKE_SOURCE_DIR}/pdf2htmlEX.1)

--- a/pdf2htmlEX/src/HTMLRenderer/form.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/form.cc
@@ -22,7 +22,7 @@ using std::cerr;
 
 void HTMLRenderer::process_form(ofstream & out)
 {
-    FormPageWidgets * widgets = cur_catalog->getPage(pageNum)->getFormWidgets();
+    std::shared_ptr<FormPageWidgets> widgets = cur_catalog->getPage(pageNum)->getFormWidgets();
     int num = widgets->getNumWidgets();
 
     for(int i = 0; i < num; i++)

--- a/pdf2htmlEX/src/HTMLRenderer/link.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/link.cc
@@ -148,7 +148,7 @@ string HTMLRenderer::get_linkaction_str(
                         dynamic_cast<const LinkGoTo*>(action);
                     std::unique_ptr<LinkDest> dest = nullptr;
                     if(auto _ = real_action->getDest())
-                        dest = std::unique_ptr<LinkDest>( _->copy() );
+                        dest = std::make_unique<LinkDest>(*_);
                     else if (auto _ = real_action->getNamedDest())
                         dest = cur_catalog->findDest(_);
                     if(dest)

--- a/pdf2htmlEX/src/HTMLRenderer/outline.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/outline.cc
@@ -52,7 +52,6 @@ void HTMLRenderer::process_outline_items(const std::vector<OutlineItem*> * items
         {
             process_outline_items(item->getKids());
         }
-        item->close();
         f_outline.fs << "</li>";
     }
 

--- a/pdf2htmlEX/src/HTMLRenderer/state.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/state.cc
@@ -207,7 +207,7 @@ void HTMLRenderer::check_state_change(GfxState * state)
     // font name & size
     if(all_changed || font_changed)
     {
-        const FontInfo * new_font_info = install_font(state->getFont());
+        const FontInfo * new_font_info = install_font(state->getFont().get());
 
         if(!(new_font_info->id == cur_text_state.font_info->id))
         {

--- a/pdf2htmlEX/src/HTMLRenderer/text.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/text.cc
@@ -95,9 +95,9 @@ void HTMLRenderer::drawString(GfxState * state, const GooString * s)
             char buf[2];
             buf[0] = (code >> 8) & 0xff;
             buf[1] = (code & 0xff);
-            width = ((GfxCIDFont *)font)->getWidth(buf, 2);
+            width = ((GfxCIDFont *)font.get())->getWidth(buf, 2);
         } else {
-            width = ((Gfx8BitFont *)font)->getWidth(code);
+            width = ((Gfx8BitFont *)font.get())->getWidth(code);
         }
 
         if (width == 0 || height == 0) {
@@ -151,11 +151,11 @@ void HTMLRenderer::drawString(GfxState * state, const GooString * s)
                 Unicode uu;
                 if(cur_text_state.font_info->use_tounicode)
                 {
-                    uu = check_unicode(u, uLen, code, font);
+                    uu = check_unicode(u, uLen, code, font.get());
                 }
                 else
                 {
-                    uu = unicode_from_font(code, font);
+                    uu = unicode_from_font(code, font.get());
                 }
                 html_text_page.get_cur_line()->append_unicodes(&uu, 1, ddx);
                 /*

--- a/pdf2htmlEX/src/Preprocessor.cc
+++ b/pdf2htmlEX/src/Preprocessor.cc
@@ -67,8 +67,7 @@ void Preprocessor::drawChar(GfxState *state, double x, double y,
       double originX, double originY,
       CharCode code, int nBytes, const Unicode *u, int uLen)
 {
-    GfxFont * font = state->getFont();
-    if(!font) return;
+    std::shared_ptr<GfxFont> font = state->getFont();
 
     long long fn_id = hash_ref(font->getID());
 

--- a/pdf2htmlEX/src/util/ffw.c
+++ b/pdf2htmlEX/src/util/ffw.c
@@ -19,7 +19,7 @@
 #include "SignalHandler.h"
 
 #include "ffw.h"                      // needed for:
-#include "gfile.h"                    //   FindProgDir
+#include "gfile.h"                    //   FindProgDir => FindProgRoot in 20230101
 #include "fontforge/autowidth.h"      //   FVRemoveKerns
 #include "fontforge/bitmapchar.h"     //   SFReplaceEncodingBDFProps
 #include "fontforge/cvimages.h"       //   FVImportImages
@@ -71,7 +71,7 @@ void ffw_init(const char* progPath, int debug)
 {
     ffwSetAction("initialize");
     char *localProgPath = strdup(progPath);
-    FindProgDir(localProgPath);
+    FindProgRoot(localProgPath);
     InitSimpleStuff();
     if ( default_encoding==NULL )
         default_encoding=FindOrMakeEncoding("ISO8859-1");
@@ -345,7 +345,7 @@ void ffw_reencode_raw2(const char ** mapping, int mapping_len, int force)
 
 void ffw_cidflatten(void)
 {
-    if(!cur_fv->sf->cidmaster) 
+    if(!cur_fv->sf->cidmaster)
     {
         fprintf(stderr, "Cannot flatten a non-CID font\n");
         return;


### PR DESCRIPTION
Hello,

I had to add support for current Poppler version ( 23.12.0 ), but I don't feel like maintaining an out-of-tree patch, so I'm sharing it with you's.

This patch is a continuation of #145 by @pablgonz .

Feedback would be much appreciated. Patch is mostly about changing data types, because Poppler added some std::shared_ptr's and std::optional's. Current version also requires C++17 .

Regards,
Vilius