### PR TITLE
Update package versions to build on ubuntu 22.04

### DIFF
--- a/buildScripts/getBuildToolsApt
+++ b/buildScripts/getBuildToolsApt
@@ -30,6 +30,6 @@ sudo apt-get $UNATTENDED install \
   dpkg                           \
   dpkg-dev                       \
   gettext                        \
-  openjdk-8-jre-headless         \
+  openjdk-17-jre-headless         \
   jq
 


### PR DESCRIPTION
This PR changes the java package requested from `openjdk-8-jre-headless` to `openjdk-17-jre-headless` to get pdf2htmlEX to build on ubuntu 22.04.