### PR TITLE
Changed syntax for downloading Poppler

### DIFF
--- a/buildScripts/getPoppler
+++ b/buildScripts/getPoppler
@@ -22,7 +22,7 @@ rm -rf poppler-data
 
 set -ev
 
-wget https://poppler.freedesktop.org/$POPPLER_VERSION.tar.xz
+wget https://gitlab.freedesktop.org/poppler/poppler-web-page/-/blob/master/$POPPLER_VERSION.tar.xz
 
 tar xvf $POPPLER_VERSION.tar.xz
 


### PR DESCRIPTION
FreeDesktop's GitLab repo has different syntax, so I updated this build script to reflect that. Note that while their GitLab page does display a permalink, it has a (random?) has in the URL so can't be called by just the version number, as far as I can tell.